### PR TITLE
Initialize Ory DBs & add Employee schema

### DIFF
--- a/docker-compose-v2.yml
+++ b/docker-compose-v2.yml
@@ -1,0 +1,412 @@
+# =============================================================================
+# Sunbird RC — Minimal Client Deployment Stack
+# =============================================================================
+# Combines the RC core services + ORY auth stack into a single file.
+# Excludes: Elasticsearch, Keycloak, Kafka, MinIO, claim-ms, metrics, etc.
+# Registry uses native PostgreSQL search (no Elasticsearch needed).
+#
+# One-time setup:
+#   docker network create sunbird-rc
+#   bash setup_vault.sh    # generates keys.txt + VAULT_TOKEN in .env
+#
+# Start backend:
+#   docker compose -f docker-compose-v2.yml --env-file .env up -d
+#
+# Start frontend (separate terminal):
+#   cd ../rc-admin && npm install && npm run dev
+#
+# Bootstrap first admin (run after registry is healthy):
+#   curl -s -X POST http://localhost:8081/api/v1/Employee/invite \
+#     -H "Content-Type: application/json" \
+#     -d '{"fullName":"Admin","email":"admin@company.com","role":"admin"}'
+#
+# Port map:
+#   5432  PostgreSQL
+#   8081  Registry
+#   8200  Vault
+#   3332  Identity Service
+#   3333  Credential Schema
+#   3005  Credential Service (host 3005 → container 3000)
+#   4433  Kratos Public
+#   4434  Kratos Admin
+#   4444  Hydra Public
+#   4445  Hydra Admin
+# =============================================================================
+
+services:
+
+  # ── Database ─────────────────────────────────────────────────────────────────
+  db:
+    image: postgres:16
+    volumes:
+      - ./${DB_DIR-db-data}:/var/lib/postgresql/data
+      - ./init-db.sh:/docker-entrypoint-initdb.d/01-init-db.sh
+      - ./init-db.sql.template:/docker-entrypoint-initdb.d/init-db.sql.template
+    ports:
+      - '5432:5432'
+    environment:
+      - POSTGRES_DB=registry
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - KRATOS_DB_PASSWORD=${KRATOS_DB_PASSWORD}
+      - HYDRA_DB_PASSWORD=${HYDRA_DB_PASSWORD}
+      - KETO_DB_PASSWORD=${KETO_DB_PASSWORD}
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U postgres']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - sunbird-rc
+
+  # ── Vault ────────────────────────────────────────────────────────────────────
+  vault:
+    image: vault:1.13.3
+    restart: always
+    environment:
+      - VAULT_ADDR=http://127.0.0.1:8200
+    cap_add:
+      - IPC_LOCK
+    command: vault server -config=/vault/config/vault.json
+    volumes:
+      - ./services/identity-service/vault/vault.json:/vault/config/vault.json
+      - ./vault-data:/vault/file
+    ports:
+      - '8200:8200'
+    healthcheck:
+      test:
+        ['CMD-SHELL', 'wget -q --spider http://127.0.0.1:8200/v1/sys/health || exit 1']
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 10s
+    networks:
+      - sunbird-rc
+
+  # ── Vault Unsealer ────────────────────────────────────────────────────────────
+  vault-unsealer:
+    image: curlimages/curl:8.6.0
+    restart: on-failure
+    depends_on:
+      vault:
+        condition: service_started
+    volumes:
+      - ./keys.txt:/keys.txt:ro
+    command: >
+      sh -c "
+        echo 'Waiting for Vault HTTP API...';
+        until curl -s http://vault:8200/v1/sys/health 2>/dev/null | grep -q 'initialized'; do
+          echo 'Vault not ready, retrying...'; sleep 2;
+        done;
+        STATUS=$$(curl -s http://vault:8200/v1/sys/health);
+        if echo \"$$STATUS\" | grep -q '\"sealed\":false'; then
+          echo 'Vault already unsealed.'; exit 0;
+        fi;
+        echo 'Unsealing Vault...';
+        KEY1=$$(awk '/Unseal Key 1:/{print $$NF}' /keys.txt);
+        KEY2=$$(awk '/Unseal Key 2:/{print $$NF}' /keys.txt);
+        KEY3=$$(awk '/Unseal Key 3:/{print $$NF}' /keys.txt);
+        curl -s -X PUT http://vault:8200/v1/sys/unseal -d \"{\\\"key\\\":\\\"$$KEY1\\\"}\" > /dev/null;
+        curl -s -X PUT http://vault:8200/v1/sys/unseal -d \"{\\\"key\\\":\\\"$$KEY2\\\"}\" > /dev/null;
+        RESULT=$$(curl -s -X PUT http://vault:8200/v1/sys/unseal -d \"{\\\"key\\\":\\\"$$KEY3\\\"}\");
+        if echo \"$$RESULT\" | grep -q '\"sealed\":false'; then
+          echo 'Vault unsealed successfully.'; exit 0;
+        else
+          echo 'ERROR: Vault still sealed after sending keys. Check keys.txt matches the initialized vault.';
+          echo \"Response: $$RESULT\";
+          exit 1;
+        fi
+      "
+    networks:
+      - sunbird-rc
+
+  # ── Identity Service ──────────────────────────────────────────────────────────
+  identity:
+    image: ghcr.io/sunbird-rc/sunbird-rc-identity-service:${RELEASE_VERSION}
+    ports:
+      - '3332:3332'
+    restart: on-failure
+    depends_on:
+      vault:
+        condition: service_healthy
+      vault-unsealer:
+        condition: service_completed_successfully
+      db:
+        condition: service_healthy
+    environment:
+      - DATABASE_URL=postgres://postgres:${POSTGRES_PASSWORD}@db:5432/registry
+      - VAULT_ADDR=${VAULT_ADDR}
+      - VAULT_TOKEN=${VAULT_TOKEN}
+      - VAULT_BASE_URL=${VAULT_BASE_URL}
+      - VAULT_ROOT_PATH=${VAULT_ROOT_PATH}
+      - VAULT_TIMEOUT=${VAULT_TIMEOUT}
+      - VAULT_PROXY=${VAULT_PROXY}
+      - SIGNING_ALGORITHM=${SIGNING_ALGORITHM}
+      - JWKS_URI=${JWKS_URI}
+      - ENABLE_AUTH=false
+      - WEB_DID_BASE_URL=${WEB_DID_BASE_URL}
+    healthcheck:
+      test:
+        ['CMD-SHELL', 'curl -s http://localhost:3332/health -o /dev/null || exit 1']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - sunbird-rc
+
+  # ── Credential Schema Service ─────────────────────────────────────────────────
+  credential-schema:
+    build: ./services/credential-schema
+    ports:
+      - '3333:3333'
+    depends_on:
+      db:
+        condition: service_healthy
+      identity:
+        condition: service_healthy
+    environment:
+      - DATABASE_URL=postgres://postgres:${POSTGRES_PASSWORD}@db:5432/registry
+      - IDENTITY_BASE_URL=${IDENTITY_BASE_URL}
+      - JWKS_URI=${JWKS_URI}
+      - ENABLE_AUTH=false
+    healthcheck:
+      test:
+        ['CMD-SHELL', 'curl -s http://localhost:3333/health -o /dev/null || exit 1']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - sunbird-rc
+
+  # ── Credential Service ────────────────────────────────────────────────────────
+  credential:
+    build: ./services/credentials-service
+    ports:
+      - '3005:3000'
+    depends_on:
+      db:
+        condition: service_healthy
+      identity:
+        condition: service_healthy
+      credential-schema:
+        condition: service_healthy
+    environment:
+      - DATABASE_URL=postgres://postgres:${POSTGRES_PASSWORD}@db:5432/registry
+      - IDENTITY_BASE_URL=${IDENTITY_BASE_URL}
+      - SCHEMA_BASE_URL=${SCHEMA_BASE_URL}
+      - CREDENTIAL_SERVICE_BASE_URL=${CREDENTIAL_SERVICE_BASE_URL}
+      - JWKS_URI=${JWKS_URI}
+      - ENABLE_AUTH=false
+      - QR_TYPE=W3C_VC
+    healthcheck:
+      test:
+        ['CMD-SHELL', 'curl -s http://localhost:3000/health -o /dev/null || exit 1']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - sunbird-rc
+
+  # ── Registry ──────────────────────────────────────────────────────────────────
+  # Uses native PostgreSQL search — no Elasticsearch needed.
+  # expand_reference=true required for the flat Employee schema API responses.
+  registry:
+    image: ghcr.io/sunbird-rc/sunbird-rc-core:${RELEASE_VERSION}
+    restart: on-failure
+    volumes:
+      - ./${SCHEMA_DIR-java/registry/src/main/resources/public/_schemas}:/home/sunbirdrc/config/public/_schemas
+      - ./${VIEW_DIR-java/registry/src/main/resources/views}:/home/sunbirdrc/config/views/
+    environment:
+      - connectionInfo_uri=jdbc:postgresql://db:5432/registry
+      - connectionInfo_username=postgres
+      - connectionInfo_password=${POSTGRES_PASSWORD}
+      # Auth — validates JWTs via Hydra JWKS
+      - oauth2_resource_uri=http://hydra:4444
+      - oauth2_resource_roles_path=ext.role
+      - oauth2_resource_email_path=ext.email
+      - registry_system_base_roles=admin
+      - authentication_enabled=true
+      # Native search (no Elasticsearch)
+      - search_providerName=dev.sunbirdrc.registry.service.NativeSearchService
+      - elastic_search_enabled=false
+      # VC / Signature
+      - signature_enabled=${SIGNATURE_ENABLED-true}
+      - signature_provider=dev.sunbirdrc.registry.service.impl.SignatureV2ServiceImpl
+      - did_enabled=true
+      - did_health_check_url=http://identity:3332/health
+      - did_generate_url=http://identity:3332/did/generate
+      - did_resolve_url=http://identity:3332/did/resolve/{id}
+      - signature_v2_credential_did_method=rcw
+      - signature_v2_issuer_did_method=issuer
+      - signature_v2_schema_author=Registry
+      - signature_v2_schema_author_did_method=author
+      - signature_v2_health_check_url=http://credential:3000/health
+      - signature_v2_issue_url=http://credential:3000/credentials/issue
+      - signature_v2_get_url=http://credential:3000/credentials/{id}
+      - signature_v2_verify_url=http://credential:3000/credentials/{id}/verify
+      - signature_v2_schema_health_check_url=http://credential-schema:3333/health
+      - signature_v2_schema_create_url=http://credential-schema:3333/credential-schema
+      - signature_v2_schema_update_url=http://credential-schema:3333/credential-schema/{id}/{version}
+      - signature_v2_schema_get_by_id_and_version_url=http://credential-schema:3333/credential-schema/{id}/{version}
+      - signature_v2_schema_search_by_tags_url=http://credential-schema:3333/credential-schema?tags={tags}
+      - certificate_enabled=false
+      - template_base_url=http://registry:8081/api/v1/templates/
+      - enable_external_templates=true
+      # Disabled features
+      - encryption_enabled=false
+      - event_enabled=false
+      - claims_enabled=false
+      - idgen_enabled=false
+      - filestorage_enabled=false
+      - notification_enabled=false
+      - async_enabled=false
+      - webhook_enabled=false
+      - WORKFLOW_ENABLED=false
+      # General
+      - identity_provider=dev.sunbirdrc.auth.keycloak.KeycloakProviderImpl
+      - manager_type=DefinitionsManager
+      - expand_reference=true
+      - registry_base_apis_enable=false
+      - logging.level.root=INFO
+    ports:
+      - '8081:8081'
+    depends_on:
+      db:
+        condition: service_healthy
+      credential:
+        condition: service_healthy
+    healthcheck:
+      test:
+        ['CMD-SHELL', 'wget -nv -t1 --spider http://localhost:8081/health || exit 1']
+      interval: 30s
+      timeout: 10s
+      retries: 10
+    networks:
+      - sunbird-rc
+
+  # ── Kratos ────────────────────────────────────────────────────────────────────
+  kratos-migrate:
+    image: oryd/kratos:v1.0.0
+    environment:
+      DSN: postgres://kratos:${KRATOS_DB_PASSWORD}@db:5432/kratos?sslmode=disable
+    volumes:
+      - ./ory/kratos:/etc/config/kratos
+    command: -c /etc/config/kratos/kratos.yml migrate sql -e --yes
+    restart: on-failure
+    networks:
+      - sunbird-rc
+
+  kratos:
+    image: oryd/kratos:v1.0.0
+    depends_on:
+      kratos-migrate:
+        condition: service_completed_successfully
+      db:
+        condition: service_healthy
+    environment:
+      DSN: postgres://kratos:${KRATOS_DB_PASSWORD}@db:5432/kratos?sslmode=disable
+      LOG_LEVEL: info
+    volumes:
+      - ./ory/kratos:/etc/config/kratos
+    command: serve -c /etc/config/kratos/kratos.yml --dev --watch-courier
+    ports:
+      - "4433:4433"
+      - "4434:4434"
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:4433/health/alive"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    networks:
+      - sunbird-rc
+
+  # ── Hydra ────────────────────────────────────────────────────────────────────
+  hydra-migrate:
+    image: oryd/hydra:v2.2.0
+    environment:
+      DSN: postgres://hydra:${HYDRA_DB_PASSWORD}@db:5432/hydra?sslmode=disable
+    command: migrate sql -e --yes
+    restart: on-failure
+    networks:
+      - sunbird-rc
+
+  hydra:
+    image: oryd/hydra:v2.2.0
+    depends_on:
+      hydra-migrate:
+        condition: service_completed_successfully
+      db:
+        condition: service_healthy
+    environment:
+      DSN: postgres://hydra:${HYDRA_DB_PASSWORD}@db:5432/hydra?sslmode=disable
+      LOG_LEVEL: info
+      SECRETS_SYSTEM: ${HYDRA_SYSTEM_SECRET}
+      SECRETS_COOKIE: ${HYDRA_COOKIE_SECRET}
+      OIDC_SUBJECT_IDENTIFIERS_PAIRWISE_SALT: ${HYDRA_PAIRWISE_SALT}
+    volumes:
+      - ./ory/hydra:/etc/config/hydra
+    command: serve all --config /etc/config/hydra/hydra.yml --dev
+    ports:
+      - "4444:4444"
+      - "4445:4445"
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:4444/health/alive"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    networks:
+      - sunbird-rc
+
+  # ── Hydra Client Bootstrap ────────────────────────────────────────────────────
+  hydra-client-init:
+    image: curlimages/curl:latest
+    depends_on:
+      hydra:
+        condition: service_healthy
+    environment:
+      RC_CLIENT_SECRET: ${RC_CLIENT_SECRET}
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        echo "==> Registering rc-admin OAuth2 client..."
+        CLIENT_JSON="{
+          \"client_id\":   \"rc-client\",
+          \"client_name\": \"Sunbird RC Admin\",
+          \"client_secret\": \"${RC_CLIENT_SECRET}\",
+          \"grant_types\":  [\"authorization_code\", \"refresh_token\", \"client_credentials\"],
+          \"response_types\": [\"code\"],
+          \"scope\": \"openid offline_access email profile\",
+          \"redirect_uris\": [
+            \"http://{{host}}:3000/callback\",
+            \"http://{{host}}:3000/\"
+          ],
+          \"post_logout_redirect_uris\": [
+            \"http://{{host}}:3000/login\",
+            \"http://{{host}}:3000/\"
+          ],
+          \"token_endpoint_auth_method\": \"client_secret_post\",
+          \"subject_type\": \"public\"
+        }"
+        STATUS=$$(curl -s -o /tmp/resp.json -w "%{http_code}" \
+          -X POST http://hydra:4445/admin/clients \
+          -H "Content-Type: application/json" \
+          -d "$$CLIENT_JSON")
+        case "$$STATUS" in
+          201) echo "==> Client registered." ;;
+          409)
+            echo "==> Client already exists — updating..."
+            STATUS=$$(curl -s -o /tmp/resp.json -w "%{http_code}" \
+              -X PUT http://hydra:4445/admin/clients/rc-client \
+              -H "Content-Type: application/json" \
+              -d "$$CLIENT_JSON")
+            [ "$$STATUS" = "200" ] && echo "==> Client updated." || { echo "==> Update FAILED (HTTP $$STATUS):"; cat /tmp/resp.json; exit 1; }
+            ;;
+          *)   echo "==> FAILED (HTTP $$STATUS):"; cat /tmp/resp.json; exit 1 ;;
+        esac
+    restart: on-failure
+    networks:
+      - sunbird-rc
+
+networks:
+  sunbird-rc:
+    external: true

--- a/java/registry/src/main/resources/application.yml
+++ b/java/registry/src/main/resources/application.yml
@@ -50,7 +50,7 @@ invite:
 cors:
   # By default, allowing all domains to access this service. Choose a particular domain,
   # in production. For example, http://otherservice.com:9090, to allow requests from otherservice.com.
-  allowedOrigin: ${cors_allowedOrigin:http://localhost:5173,http://localhost:4433,http://localhost:4444}
+  allowedOrigin: ${cors_allowedOrigin:*}
 
 perf:
   monitoring:

--- a/java/registry/src/main/resources/application.yml
+++ b/java/registry/src/main/resources/application.yml
@@ -17,11 +17,11 @@ spring:
 
 oauth2:
   resources:
-    - uri: ${oauth2_resource_uri:http://localhost:8080/auth/realms/sunbird-rc}
+    - uri: ${oauth2_resource_uri:http://localhost:4444}
       properties:
         emailPath: ${oauth2_resource_email_path:email}
         consentPath: ${oauth2_resource_consent_path:consent}
-        rolesPath: ${oauth2_resource_roles_path:realm_access.roles}
+        rolesPath: ${oauth2_resource_roles_path:role}
         entityPath: ${oauth2_resource_entity_path:entity}
         userIdPath: ${oauth2_resource_user_id_path:sub}
 
@@ -50,7 +50,7 @@ invite:
 cors:
   # By default, allowing all domains to access this service. Choose a particular domain,
   # in production. For example, http://otherservice.com:9090, to allow requests from otherservice.com.
-  allowedOrigin: ${cors_allowedOrigin:*}
+  allowedOrigin: ${cors_allowedOrigin:http://localhost:5173,http://localhost:4433,http://localhost:4444}
 
 perf:
   monitoring:
@@ -67,6 +67,7 @@ registry:
     base: ${registry_context_base:http://localhost:8081/}
   system:
     base: ${registry_system_base:http://localhost:8081/sunbirdrc/}
+    base_roles: ${registry_system_base_roles:admin}
   rootEntity:
     type: ${registry_rootentity_type:Teacher}
   schema:
@@ -80,7 +81,7 @@ registry:
     host: ${redis_host:localhost}
     port: ${redis_port:6379}
   hard_delete_enabled: ${hard_delete_enabled:false}
-  expandReference: ${expand_reference:false}
+  expandReference: ${expand_reference:true}
 workflow:
   enabled: ${workflow.enable:true}
 
@@ -474,15 +475,15 @@ signature:
 # suffixSeperator : specifies the separator used between entity name and suffix. If audit schema name is Teacher_Audit.json, the suffixSeperator is _.
 
 audit:
-  enabled: true
-  vc-enabled: true
+  enabled: ${audit_enabled:false}
+  vc-enabled: ${audit_vc_enabled:false}
   frame:
-    store: DATABASE
-    suffix: Audit
-    suffixSeparator: _
+    store: ${audit_frame_store:DATABASE}
+    suffix: ${audit_suffix:Audit}
+    suffixSeparator: ${audit_suffixSeparator:_}
 
 authentication:
-  enabled: ${authentication_enabled:true}
+  enabled: ${authentication_enabled:false}
   publicKey:  ${authentication_publickey:MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqe1lVD9jnQWQce62e2Q44tACqBIt5UZyGzCegxax2gddj4xotY5BDxaxuJRGKDLRpm8lPNHxX8dce8SUVAMBfk85rL+Bxv1mjspKo7Q5qsFm9TGcvE4e/4xhgpMjw6dCFt8+S87jvRjmDHjakGMooOls1kjppQiklSEZ0lW3Crqet4RNjb1FNJ+2Jg26frm8i2cpb2wRnmLDuQ9sAnHCxAD2rGxSGLXhKABptbMeTVx25eh+PVISjc78uOhAnMwOHKApVBGnVCfcUoVYqfkX8XcPQU9ybmAi27vp9xZqMfh6I56Tl4fsWYBgf8ZMl0UWyRR3PNmo/0kxon1d3zqFnwIDAQAB}
   realm:  ${authentication_realm:PartnerRegistry}
   url:  ${authentication_url:http://localhost:8443/auth/}
@@ -546,9 +547,3 @@ elastic:
     # elastic-search connection info
     connection_url: ${elastic_search_connection_url:localhost:9200}
 
-idgen:
-  enabled: true
-  tenantId: default
-  healthCheckURL: http://localhost:8088/egov-idgen/health
-  generateURL: http://localhost:8088/egov-idgen/id/_generate
-  idFormatURL: http://localhost:8088/egov-idgen/id/_format/add

--- a/java/registry/src/main/resources/public/_schemas/Employee.json
+++ b/java/registry/src/main/resources/public/_schemas/Employee.json
@@ -1,0 +1,162 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "type": "object",
+    "properties": {
+        "Employee": {
+            "$ref": "#/definitions/Employee"
+        }
+    },
+    "required": [
+        "Employee"
+    ],
+    "title": "Employee",
+    "definitions": {
+        "Employee": {
+            "$id": "#/properties/Employee",
+            "type": "object",
+            "title": "The Employee Schema",
+            "required": [],
+            "properties": {
+                "fullName": {
+                    "type": "string"
+                },
+                "personalIdentification": {
+                    "type": "string"
+                },
+                "typeIdentification": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string"
+                },
+                "mobile": {
+                    "type": "string"
+                },
+                "role": {
+                    "type": "string",
+                    "enum": [
+                        "admin",
+                        "employee"
+                    ]
+                },
+                "positionName": {
+                    "type": "string"
+                },
+                "departmentName": {
+                    "type": "string"
+                },
+                "companyName": {
+                    "type": "string"
+                },
+                "admissionDate": {
+                    "type": "string"
+                },
+                "contractExpiration": {
+                    "type": "string"
+                },
+                "statusName": {
+                    "type": "string"
+                },
+                "salary": {
+                    "type": "string"
+                }
+            }
+        }
+    },
+    "_osConfig": {
+        "uniqueIndexFields": [
+            "email"
+        ],
+        "ownershipAttributes": [
+            {
+                "email": "/email",
+                "userId": "/email"
+            }
+        ],
+        "privateFields": [
+            "/salary"
+        ],
+        "roleBasedAccessControl": {
+            "admin": {
+                "create": {
+                    "allow": [
+                        "*"
+                    ]
+                },
+                "read": {
+                    "allow": [
+                        "*"
+                    ]
+                },
+                "update": {
+                    "allow": [
+                        "*"
+                    ]
+                }
+            },
+            "employee": {
+                "read": {
+                    "osOwner": true
+                },
+                "update": {
+                    "osOwner": true
+                }
+            }
+        },
+        "roles": [
+            "admin",
+            "employee"
+        ],
+        "inviteRoles": [
+            "anonymous"
+        ],
+        "credentialTemplate": {
+            "@context": [
+                "https://www.w3.org/2018/credentials/v1",
+                {
+                    "@context": {
+                        "@version": 1.1,
+                        "@protected": true,
+                        "Employee": {
+                            "@id": "https://github.com/sunbird-specs/vc-specs#Employee",
+                            "@context": {
+                                "id": "@id",
+                                "@version": 1.1,
+                                "@protected": true,
+                                "name": "schema:Text",
+                                "personalIdentification": "schema:Text",
+                                "documentType": "schema:Text",
+                                "position": "schema:Text",
+                                "department": "schema:Text",
+                                "institution": "schema:Text",
+                                "dateOfHire": "schema:Text",
+                                "exitDate": "schema:Text",
+                                "status": "schema:Text"
+                            }
+                        }
+                    }
+                }
+            ],
+            "type": [
+                "VerifiableCredential"
+            ],
+            "issuanceDate": "2021-08-27T10:57:57.237Z",
+            "credentialSubject": {
+                "type": "Employee",
+                "name": "{{fullName}}",
+                "personalIdentification": "{{personalIdentification}}",
+                "documentType": "{{typeIdentification}}",
+                "position": "{{positionName}}",
+                "department": "{{departmentName}}",
+                "institution": "{{companyName}}",
+                "dateOfHire": "{{admissionDate}}",
+                "exitDate": "{{contractExpiration}}",
+                "status": "{{statusName}}"
+            },
+            "issuer": "did:web:sunbirdrc.dev/vc/Employee"
+        },
+        "certificateTemplates": {
+            "html": "http://localhost:8081/api/v1/templates/Employee.html"
+        }
+    }
+}

--- a/java/registry/src/main/resources/public/templates/Employee.html
+++ b/java/registry/src/main/resources/public/templates/Employee.html
@@ -1,0 +1,181 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <style>
+    body {
+      font-family: 'Georgia', serif;
+      background: #f5f5f5;
+      margin: 0;
+      padding: 0;
+    }
+    .certificate {
+      width: 900px;
+      margin: 40px auto;
+      background: #fff;
+      border: 12px solid #1a3a6b;
+      border-radius: 8px;
+      padding: 40px 60px;
+      box-shadow: 0 4px 20px rgba(0,0,0,0.15);
+    }
+    .header {
+      text-align: center;
+      border-bottom: 2px solid #1a3a6b;
+      padding-bottom: 20px;
+      margin-bottom: 30px;
+    }
+    .org-name {
+      font-size: 2em;
+      font-weight: bold;
+      color: #1a3a6b;
+      letter-spacing: 2px;
+      text-transform: uppercase;
+    }
+    .cert-title {
+      font-size: 1.4em;
+      color: #444;
+      margin-top: 8px;
+      letter-spacing: 1px;
+    }
+    .intro {
+      text-align: center;
+      font-size: 1.05em;
+      color: #555;
+      margin-bottom: 30px;
+    }
+    .name-block {
+      text-align: center;
+      margin: 20px 0 30px;
+    }
+    .employee-name {
+      font-size: 2.2em;
+      font-weight: bold;
+      color: #1a3a6b;
+      border-bottom: 2px solid #c8a951;
+      display: inline-block;
+      padding-bottom: 4px;
+    }
+    .details-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 16px 40px;
+      margin: 30px 0;
+      padding: 20px 30px;
+      background: #f0f4fb;
+      border-radius: 6px;
+    }
+    .detail-item label {
+      display: block;
+      font-size: 0.78em;
+      color: #888;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+      margin-bottom: 3px;
+    }
+    .detail-item span {
+      font-size: 1.05em;
+      color: #222;
+      font-weight: 600;
+    }
+    .footer {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-end;
+      margin-top: 40px;
+      padding-top: 20px;
+      border-top: 1px solid #ddd;
+    }
+    .qr-section {
+      text-align: center;
+    }
+    .qr-section img {
+      width: 110px;
+      height: 110px;
+    }
+    .qr-section p {
+      font-size: 0.75em;
+      color: #888;
+      margin-top: 6px;
+    }
+    .signature-section {
+      text-align: center;
+    }
+    .signature-line {
+      border-top: 1px solid #333;
+      width: 200px;
+      margin: 0 auto;
+      padding-top: 8px;
+      font-size: 0.9em;
+      color: #555;
+    }
+    .issued-date {
+      text-align: center;
+      font-size: 0.85em;
+      color: #777;
+      margin-top: 6px;
+    }
+  </style>
+</head>
+<body>
+  <div class="certificate">
+    <div class="header">
+      <div class="org-name">Sunbird RC</div>
+      <div class="cert-title">Employee Certificate</div>
+    </div>
+
+    <div class="intro">
+      This is to certify that
+    </div>
+
+    <div class="name-block">
+      <div class="employee-name">{{credentialSubject.name}}</div>
+    </div>
+
+    <div class="intro">
+      is a verified employee with the following details:
+    </div>
+
+    <div class="details-grid">
+      <div class="detail-item">
+        <label>Personal ID</label>
+        <span>{{credentialSubject.personalIdentification}}</span>
+      </div>
+      <div class="detail-item">
+        <label>Email</label>
+        <span>{{credentialSubject.email}}</span>
+      </div>
+      <div class="detail-item">
+        <label>Position</label>
+        <span>{{credentialSubject.position}}</span>
+      </div>
+      <div class="detail-item">
+        <label>Department</label>
+        <span>{{credentialSubject.department}}</span>
+      </div>
+      <div class="detail-item">
+        <label>Institution</label>
+        <span>{{credentialSubject.institution}}</span>
+      </div>
+      <div class="detail-item">
+        <label>Date of Hire</label>
+        <span>{{credentialSubject.dateOfHire}}</span>
+      </div>
+      <div class="detail-item">
+        <label>Status</label>
+        <span>{{credentialSubject.status}}</span>
+      </div>
+    </div>
+
+    <div class="footer">
+      <div class="qr-section">
+        <img src="{{qrCode}}" alt="Verification QR Code" />
+        <p>Scan to verify</p>
+      </div>
+      <div class="signature-section">
+        <div class="signature-line">Authorized Signatory</div>
+        <div class="issued-date">Issued on: {{issuanceDate}}</div>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/java/registry/src/main/resources/setup_vault.sh
+++ b/java/registry/src/main/resources/setup_vault.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+# This script does the following:
+# * Waits for vault to respond on localhost:8200
+# * Initializes vault on first run: saves keys to keys.txt, updates VAULT_TOKEN in .env
+# * On restart: uses existing keys.txt to unseal (skips init)
+# * Enables kv-v2 secrets engine on first run
+
+COMPOSE_FILE="${1:-docker-compose.yml}"
+SERVICE_NAME="${2:-vault}"
+VAULT_PORT="${3:-8200}"
+
+echo "Setting up $SERVICE_NAME in $COMPOSE_FILE"
+
+# Wait for vault HTTP API to respond
+echo "Waiting for Vault to start..."
+until curl -s "http://localhost:${VAULT_PORT}/v1/sys/health" 2>/dev/null | grep -q '"initialized"'; do
+    echo "Vault not yet reachable, retrying..."
+    sleep 2
+done
+echo "Vault is reachable."
+
+# Get vault status from HTTP API (JSON response)
+vault_health=$(curl -s "http://localhost:${VAULT_PORT}/v1/sys/health" 2>/dev/null)
+
+# Get container ID for docker exec
+VAULT_CONTAINER=$(docker compose -f "$COMPOSE_FILE" ps -q "$SERVICE_NAME" | head -1)
+
+is_fresh_install=false
+
+if echo "$vault_health" | grep -q '"initialized":true'; then
+    echo "Vault is already initialized."
+    if [ ! -s "keys.txt" ]; then
+        echo "CRITICAL ERROR: Vault is initialized but keys.txt is missing!"
+        echo "You must manually provide unseal keys. Cannot proceed."
+        exit 1
+    fi
+    echo "Using existing keys.txt for unsealing."
+else
+    echo "Vault is not initialized. Initializing..."
+    docker exec "$VAULT_CONTAINER" vault operator init > ansi-keys.txt
+    sed 's/\x1B\[[0-9;]*[JKmsu]//g' < ansi-keys.txt > keys.txt
+    rm -f ansi-keys.txt
+    is_fresh_install=true
+
+    # Extract root token and update .env (portable sed: works on macOS and Linux)
+    root_token=$(sed -n 's/Initial Root Token: \(.*\)/\1/p' keys.txt | tr -dc '[:print:]')
+    sed "s/VAULT_TOKEN=.*/VAULT_TOKEN=$root_token/" ".env" > ".env.tmp" && mv ".env.tmp" ".env"
+    echo "Vault initialized. VAULT_TOKEN updated in .env"
+fi
+
+# Unseal vault with keys 1, 2, 3 (threshold = 3 of 5)
+echo "Unsealing vault..."
+key1=$(sed -n 's/Unseal Key 1: \(.*\)/\1/p' keys.txt | tr -dc '[:print:]')
+key2=$(sed -n 's/Unseal Key 2: \(.*\)/\1/p' keys.txt | tr -dc '[:print:]')
+key3=$(sed -n 's/Unseal Key 3: \(.*\)/\1/p' keys.txt | tr -dc '[:print:]')
+
+docker exec "$VAULT_CONTAINER" vault operator unseal "$key1"
+docker exec "$VAULT_CONTAINER" vault operator unseal "$key2"
+docker exec "$VAULT_CONTAINER" vault operator unseal "$key3"
+echo "Vault unsealed successfully."
+
+# Enable kv-v2 secrets engine on fresh install only
+if $is_fresh_install; then
+    root_token=$(sed -n 's/Initial Root Token: \(.*\)/\1/p' keys.txt | tr -dc '[:print:]')
+    docker exec -e VAULT_TOKEN="$root_token" "$VAULT_CONTAINER" vault secrets enable -path=kv kv-v2
+    echo "KV v2 secrets engine enabled."
+    echo ""
+    echo "Next steps:"
+    echo "  docker compose -f $COMPOSE_FILE up -d identity credential-schema credential"
+fi
+
+echo ""
+echo "NOTE: KEYS ARE STORED IN keys.txt — keep this file safe and NEVER commit it to git!"

--- a/ory/hydra/hydra.yml
+++ b/ory/hydra/hydra.yml
@@ -1,0 +1,59 @@
+serve:
+  cookies:
+    same_site_mode: Lax
+  public:
+    cors:
+      enabled: true
+      allowed_origins:
+        - http://localhost:5173   # rc-admin (Vite dev server)
+        - http://localhost:3000   # other app origins
+        - http://localhost:5555   # login-bridge (headless flows)
+  admin:
+    cors:
+      enabled: true
+      allowed_origins:
+        - http://localhost:5173   # rc-admin (Vite dev server)
+        - http://localhost:3000   # rc-admin (Docker / production)
+        - http://localhost:5555   # login-bridge
+
+urls:
+  self:
+    issuer: http://hydra:4444           # iss claim in JWTs; registry validates via Docker DNS (hydra:4444)
+
+  login:   http://localhost:3000/login   # rc-admin Login.tsx  — handles Hydra login_challenge
+  consent: http://localhost:3000/consent # rc-admin Consent.tsx — auto-accepts consent_challenge
+  logout:  http://localhost:3000/logout
+
+# ── DSN (injected via SECRETS_SYSTEM / SECRETS_COOKIE env vars in docker-compose) ──
+dsn: ${DSN}
+
+# ── Token Strategy ────────────────────────────────────────────────────────────
+strategies:
+  access_token: jwt     # signed JWTs — no introspection call needed by consumers
+  scope: wildcard
+
+# ── OAuth2 ────────────────────────────────────────────────────────────────────
+oauth2:
+  expose_internal_errors: true
+  mirror_top_level_claims: true  # copies id_token claims into access_token payload
+
+# ── OIDC ──────────────────────────────────────────────────────────────────────
+oidc:
+  subject_identifiers:
+    supported_types:
+      - public
+    pairwise:
+      salt: ${OIDC_SUBJECT_IDENTIFIERS_PAIRWISE_SALT}
+
+# ── Token TTLs ────────────────────────────────────────────────────────────────
+ttl:
+  access_token: 1h
+  refresh_token: 720h   # 30 days (offline_access scope)
+  id_token: 1h
+  auth_code: 10m
+  login_consent_request: 30m
+
+# ── Logging ───────────────────────────────────────────────────────────────────
+log:
+  level: debug
+  format: text

--- a/ory/kratos/identity.schema.json
+++ b/ory/kratos/identity.schema.json
@@ -1,0 +1,40 @@
+{
+  "$id": "https://schemas.ory.sh/presets/kratos/identity.email.schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Person",
+  "type": "object",
+  "properties": {
+    "traits": {
+      "type": "object",
+      "properties": {
+        "email": {
+          "type": "string",
+          "format": "email",
+          "title": "E-Mail",
+          "ory.sh/kratos": {
+            "credentials": {
+              "password": { "identifier": true }
+            },
+            "verification": { "via": "email" },
+            "recovery":     { "via": "email" }
+          }
+        },
+        "name": {
+          "type": "object",
+          "properties": {
+            "first": { "type": "string", "title": "First Name" },
+            "last":  { "type": "string", "title": "Last Name" }
+          }
+        },
+        "role": {
+          "type": "string",
+          "title": "Role",
+          "enum": ["admin", "employee"],
+          "default": "employee"
+        }
+      },
+      "required": ["email"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/ory/kratos/kratos.yml
+++ b/ory/kratos/kratos.yml
@@ -1,0 +1,141 @@
+version: v1.0.0
+
+dsn: ${KRATOS_DB_DSN}
+
+# ── Server ─────────────────────────────────────────────────────────────────────
+serve:
+  public:
+    base_url: ${KRATOS_PUBLIC_URL}
+    cors:
+      enabled: true
+      allowed_origins:
+        - ${CORS_ORIGIN_1}
+        - ${CORS_ORIGIN_2}
+        - ${CORS_ORIGIN_3}
+        - ${CORS_ORIGIN_4}
+      allowed_methods:
+        - POST
+        - GET
+        - PUT
+        - PATCH
+        - DELETE
+      allowed_headers:
+        - Authorization
+        - Content-Type
+        - X-Session-Token
+        - X-CSRF-Token
+      exposed_headers:
+        - Content-Type
+  admin:
+    base_url: ${KRATOS_ADMIN_URL}
+
+# ── Self-Service Flows ─────────────────────────────────────────────────────────
+selfservice:
+  default_browser_return_url: ${KRATOS_DEFAULT_RETURN_URL}
+
+  allowed_return_urls:
+    - ${ALLOWED_RETURN_URL_1}
+    - ${ALLOWED_RETURN_URL_2}
+    - ${ALLOWED_RETURN_URL_3}
+    - ${ALLOWED_RETURN_URL_4}
+    - ${ALLOWED_RETURN_URL_5}
+    - ${ALLOWED_RETURN_URL_6}
+    - ${ALLOWED_RETURN_URL_7}
+    - ${ALLOWED_RETURN_URL_8}
+
+  methods:
+    password:
+      enabled: false
+    oidc:
+      enabled: true
+      config:
+        providers:
+          - id: cuenta-digital
+            provider: generic
+            client_id: ${OIDC_CLIENT_ID}
+            client_secret: ${OIDC_CLIENT_SECRET}
+            issuer_url: ${OIDC_ISSUER_URL}
+            scope:
+              - openid
+              - email
+              - profile
+            mapper_url: file:///etc/config/kratos/oidc.cuenta.jsonnet
+    totp:
+      enabled: false
+    lookup_secret:
+      enabled: false
+    link:
+      enabled: false
+    code:
+      enabled: false
+
+  flows:
+    error:
+      ui_url: ${KRATOS_ERROR_UI_URL}
+
+    settings:
+      ui_url: ${KRATOS_SETTINGS_UI_URL}
+      lifespan: 10m
+      after:
+        default_browser_return_url: ${KRATOS_DEFAULT_RETURN_URL}
+
+    recovery:
+      enabled: false
+
+    verification:
+      enabled: true
+      ui_url: ${KRATOS_VERIFICATION_UI_URL}
+      after:
+        default_browser_return_url: ${KRATOS_DEFAULT_RETURN_URL}
+
+    logout:
+      after:
+        default_browser_return_url: ${KRATOS_LOGOUT_RETURN_URL}
+
+    login:
+      ui_url: ${KRATOS_LOGIN_UI_URL}
+      lifespan: 10m
+      after:
+        default_browser_return_url: ${KRATOS_DEFAULT_RETURN_URL}
+
+    registration:
+      ui_url: ${KRATOS_REGISTRATION_UI_URL}
+      lifespan: 10m
+      after:
+        default_browser_return_url: ${KRATOS_DEFAULT_RETURN_URL}
+
+# ── Identity Schema ────────────────────────────────────────────────────────────
+identity:
+  default_schema_id: default
+  schemas:
+    - id: default
+      url: file:///etc/config/kratos/identity.schema.json
+
+# ── Secrets ────────────────────────────────────────────────────────────────────
+secrets:
+  cookie:
+    - ${KRATOS_COOKIE_SECRET}
+  cipher:
+    - ${KRATOS_CIPHER_SECRET}
+
+# ── Courier (SMTP required by schema even when unused) ────────────────────────
+courier:
+  smtp:
+    connection_uri: ${KRATOS_SMTP_CONNECTION_URI}
+
+ciphers:
+  algorithm: xchacha20-poly1305
+
+hashers:
+  algorithm: bcrypt
+  bcrypt:
+    cost: 8
+
+session:
+  whoami:
+    required_aal: aal1
+
+log:
+  level: debug
+  format: text
+  leak_sensitive_values: true

--- a/ory/kratos/oidc.cuenta.jsonnet
+++ b/ory/kratos/oidc.cuenta.jsonnet
@@ -1,0 +1,16 @@
+// Maps OIDC claims from cuenta.digital.gob.do into Kratos identity traits.
+// Standard OIDC claims: email, given_name, family_name.
+// Role defaults to "employee" (per identity.schema.json); not mapped from IdP.
+local claims = std.extVar('claims');
+
+{
+  identity: {
+    traits: {
+      email: claims.email,
+      [if 'given_name' in claims || 'family_name' in claims then 'name']: {
+        [if 'given_name' in claims then 'first']: claims.given_name,
+        [if 'family_name' in claims then 'last']: claims.family_name,
+      },
+    },
+  },
+}


### PR DESCRIPTION
This PR sets up the required PostgreSQL databases and users for Ory services (Kratos, Hydra) and introduces the foundational pieces for employee credential support.

It includes:

Configuration updates (docker-compose-v2.yml, hydra.yml, kratos.yml) to connect services
Vault setup script (setup_vault.sh) for managing secrets
Employee credential assets (Employee.json, Employee.html, identity.schema.json, oidc.cuenta.jsonnet)

These changes automate infrastructure setup for identity/auth services and enable issuing and rendering employee certificates.